### PR TITLE
BUG: Creating personal schedule fails first try until quarter field changed

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,6 +20,10 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  if (!localStorage.getItem(controlId)) {
+    localStorage.setItem(controlId, quarters[0].yyyyq);
+  }
+  
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -23,7 +23,6 @@ function SingleQuarterDropdown({
   if (!localStorage.getItem(controlId)) {
     localStorage.setItem(controlId, quarters[0].yyyyq);
   }
-  
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,9 +20,10 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-  if (!localStorage.getItem(controlId)) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
+  if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
+    localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
+  
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -23,7 +23,6 @@ function SingleQuarterDropdown({
   if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
     localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
-  
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -148,4 +148,31 @@ describe("SingleQuarterSelector tests", () => {
 
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
   });
+
+  test("localStorage has a value when rendered", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+
+    const setQuarterStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
+
+    jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <SingleQuarterDropdown
+        quarters={quarterRange("20201", "20224")}
+        quarter={quarter}
+        setQuarter={setQuarter}
+        controlId="sqd1"
+      />,
+    );
+
+    await waitFor(
+      () => expect(useState).toBeCalledWith("20201"),
+      expect(localStorage.setItem).toBeCalledWith(
+        "PersonalScheduleForm-quarter",
+        "20201",
+      ),
+    );
+  });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -149,14 +149,11 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
   });
 
-  test("localStorage has a value when rendered", async () => {
+  test("when localstorage has no value, localstorage is set to first element of quarters", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
-    const setQuarterStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
-
-    jest.spyOn(Storage.prototype, "setItem");
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
 
     render(
       <SingleQuarterDropdown
@@ -167,12 +164,6 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(
-      () => expect(useState).toBeCalledWith("20201"),
-      expect(localStorage.setItem).toBeCalledWith(
-        "PersonalScheduleForm-quarter",
-        "20201",
-      ),
-    );
+    await waitFor(() => expect(setItemSpy).toBeCalledWith("sqd1", "20201"));
   });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -149,11 +149,14 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
   });
 
-  test("when localstorage has no value, localstorage is set to first element of quarters", async () => {
+  test("localStorage has a value when rendered", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
-    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    const setQuarterStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
+
+    jest.spyOn(Storage.prototype, "setItem");
 
     render(
       <SingleQuarterDropdown
@@ -164,6 +167,12 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(() => expect(setItemSpy).toBeCalledWith("sqd1", "20201"));
+    await waitFor(
+      () => expect(useState).toBeCalledWith("20201"),
+      expect(localStorage.setItem).toBeCalledWith(
+        "PersonalScheduleForm-quarter",
+        "20201",
+      ),
+    );
   });
 });


### PR DESCRIPTION
In this pr, I resolved the bug where personal schedule is failing before the quarter field is changed.

Dokku Link: https://proj-courses-mu.dokku-11.cs.ucsb.edu/

Test in incognito mode as this should reset the localstorage. Click on "Personal Schedules," select "Add Schedule," and enter a name and description but click "create" without changing the quarter. 

close #7