### PR TITLE
Add Info Column to Searches

### DIFF
--- a/frontend/src/main/components/Courses/CourseTable.js
+++ b/frontend/src/main/components/Courses/CourseTable.js
@@ -38,8 +38,8 @@ export default function CourseTable({ courses, currentUser }) {
 
   const columnsIfUser = [
     ...columns,
-    // ButtonColumn("Edit", "primary", editCallback, "PersonalSchedulesTable"),
-    ButtonColumn("Delete", "danger", deleteCallback, "CourseTable"),
+    // ButtonColumn("Edit", "Edit", "primary", editCallback, "PersonalSchedulesTable"),
+    ButtonColumn("Delete", "Delete", "danger", deleteCallback, "CourseTable"),
   ];
 
   const columnsToDisplay = hasRole(currentUser, "ROLE_USER")

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -90,11 +90,11 @@ export default function OurTable({
 //       Header: 'Name',
 //       accessor: 'name',
 //   },
-//   ButtonColumn("Edit", "primary", editCallback),
-//   ButtonColumn("Delete", "danger", deleteCallback)
+//   ButtonColumn("Edit", "Edit","primary", editCallback),
+//   ButtonColumn("Delete", "Delete", "danger", deleteCallback)
 // ];
 
-export function ButtonColumn(label, variant, callback, testid) {
+export function ButtonColumn(label, celltext, variant, callback, testid) {
   const column = {
     Header: label,
     id: label,
@@ -104,7 +104,7 @@ export function ButtonColumn(label, variant, callback, testid) {
         onClick={() => callback(cell)}
         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
       >
-        {label}
+        {celltext}
       </Button>
     ),
   };

--- a/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
@@ -59,12 +59,13 @@ export default function PersonalSchedulesTable({
     ...columns,
     ButtonColumn(
       "Details",
+      "Details",
       "primary",
       detailsCallback,
       "PersonalSchedulesTable",
     ),
-    ButtonColumn("Edit", "primary", editCallback, "PersonalSchedulesTable"),
-    ButtonColumn("Delete", "danger", deleteCallback, "PersonalSchedulesTable"),
+    ButtonColumn("Edit", "Edit", "primary", editCallback, "PersonalSchedulesTable"),
+    ButtonColumn("Delete", "Delete", "danger", deleteCallback, "PersonalSchedulesTable"),
   ];
 
   const columnsToDisplay = showButtons ? buttonColumns : columns;

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -1,4 +1,6 @@
 import SectionsOverTimeTableBase from "main/components/SectionsOverTimeTableBase";
+import { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import {
@@ -22,6 +24,13 @@ function getCourseId(courseIds) {
 }
 
 export default function SectionsOverTimeTable({ sections }) {
+  const navigate = useNavigate();
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const infoCallback = () => {
+    navigate(`/coursedetails/`);
+  };
+
   // Stryker enable all
   // Stryker disable BooleanLiteral
   const columns = [
@@ -127,6 +136,8 @@ export default function SectionsOverTimeTable({ sections }) {
       Aggregated: ({ cell: { value } }) => `${value}`,
     },
   ];
+
+  columns.unshift(ButtonColumn("Info", "ℹ", "primary", infoCallback, "SectionsOverTimeTable"));
 
   const testid = "SectionsOverTimeTable";
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -1,4 +1,6 @@
 import SectionsTableBase from "main/components/SectionsTableBase";
+import { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import {
@@ -18,6 +20,13 @@ function getFirstVal(values) {
 }
 
 export default function SectionsTable({ sections }) {
+  const navigate = useNavigate();
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const infoCallback = () => {
+    navigate(`/coursedetails/`);
+  };
+
   // Stryker enable all
   // Stryker disable BooleanLiteral
   const columns = [
@@ -120,6 +129,8 @@ export default function SectionsTable({ sections }) {
       Aggregated: ({ cell: { value } }) => `${value}`,
     },
   ];
+
+  columns.unshift(ButtonColumn("Info", "ℹ", "primary", infoCallback, "SectionsTable"));
 
   const testid = "SectionsTable";
 

--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -58,8 +58,8 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
 
   const columnsIfAdmin = [
     ...columns,
-    ButtonColumn("Edit", "primary", editCallback, "UCSBSubjectsTable"),
-    ButtonColumn("Delete", "danger", deleteCallback, "UCSBSubjectsTable"),
+    ButtonColumn("Edit", "Edit", "primary", editCallback, "UCSBSubjectsTable"),
+    ButtonColumn("Delete", "Delete", "danger", deleteCallback, "UCSBSubjectsTable"),
   ];
 
   const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN")

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -37,7 +37,7 @@ describe("OurTable tests", () => {
       Header: "Column 2",
       accessor: "col2",
     },
-    ButtonColumn("Click", "primary", clickMeCallback, "testId"),
+    ButtonColumn("Click", "Click", "primary", clickMeCallback, "testId"),
     DateColumn("Date", (cell) => cell.row.original.createdAt),
     PlaintextColumn("Log", (cell) => cell.row.original.log),
   ];

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import {
   fiveSections,
   sixSections,
@@ -151,6 +151,9 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
     ).toHaveTextContent("CMPSC 130A");
+    const infoButton = screen.queryByTestId(`${testId}-cell-row-0-col-Info-button`);
+    expect(infoButton).toBeInTheDocument();
+    expect(infoButton).toHaveClass("btn-primary");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
     ).not.toHaveTextContent("CMPSC 130A -1");
@@ -181,6 +184,30 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("08078");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={sixSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "SectionsOverTimeTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("CMPSC 130A");
+
+    const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
+    expect(infoButton).toBeInTheDocument();
+    
+    fireEvent.click(infoButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/coursedetails/'));
+
   });
 
   test("Correctly groups separate quarters of the same class", async () => {
@@ -234,6 +261,7 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-2-col-enrolled`),
     ).toHaveTextContent("21/21");
   });
+  
   test("Sections have appropriate status columns", () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -144,6 +144,9 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
     ).toHaveTextContent("ECE 1A");
+    const infoButton = screen.queryByTestId(`${testId}-cell-row-0-col-Info-button`);
+    expect(infoButton).toBeInTheDocument();
+    expect(infoButton).toHaveClass("btn-primary");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`),
     ).toHaveTextContent("COMP ENGR SEMINAR");
@@ -171,6 +174,30 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("12583");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "SectionsTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 1A");
+
+    const infoButton = screen.getByTestId(`${testId}-cell-row-0-col-Info-button`);
+    expect(infoButton).toBeInTheDocument();
+    
+    fireEvent.click(infoButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/coursedetails/'));
+
   });
 
   test("Correctly groups separate lectures of the same class", async () => {


### PR DESCRIPTION
Closes #19 

Adds a column for the information icon (which will eventually route to the course details page for that specific cell).

**Before:**
<img width="1440" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-3/assets/32380357/0f341822-a435-4f7f-b7e8-e861ab0203d6">

**After:**
<img width="1440" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-3/assets/32380357/cc41c1ba-878a-4136-b677-a730a988ead0">


Same with Course History, Course Location History, and Search by Instructor:
<img width="1440" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-3/assets/32380357/204bd4b6-bf63-41b7-bf1f-7c8d84c8c39e">

Notes: Will need to merge the placeholder PR in before merging into main (and update the routing of the info button!)